### PR TITLE
Http fixes

### DIFF
--- a/bin/marathon_deploy
+++ b/bin/marathon_deploy
@@ -21,6 +21,8 @@ options[:logfile] = MarathonDeploy::MarathonDefaults::DEFAULT_LOGFILE
 options[:force] = MarathonDeploy::MarathonDefaults::DEFAULT_FORCE_DEPLOY
 options[:noop] = MarathonDeploy::MarathonDefaults::DEFAULT_NOOP
 options[:remove_elements] = MarathonDeploy::MarathonDefaults::DEFAULT_REMOVE_ELEMENTS
+options[:marathon_username] = nil
+options[:marathon_password] = nil
   
   
 OptionParser.new do |opts|
@@ -29,6 +31,14 @@ OptionParser.new do |opts|
   
   opts.on("-u","--url MARATHON_URL(S)", Array, "Default: #{options[:marathon_endpoints]}") do |u|    
     options[:marathon_endpoints] = u  
+  end
+
+  opts.on("-U","--username USERNAME", "Marathon authentication username") do |u|
+    options[:marathon_username] = u
+  end
+
+  opts.on("-p","--password PASSWORD", "Marathon authentication password") do |p|
+    options[:marathon_password] = p
   end
     
   opts.on("-l", "--logfile LOGFILE", "Default: STDOUT") do |l|
@@ -88,6 +98,11 @@ elsif (File.file?(DEFAULT_DEPLOYFILE))
   deployfile = DEFAULT_DEPLOYFILE
 else
   abort("No deploy file argument provided and default \'#{DEFAULT_DEPLOYFILE}\' does not exist in current directory \'#{Dir.pwd}\'")  
+end
+
+if options[:marathon_username] and options[:marathon_password]
+  MarathonDeploy::MarathonDefaults::marathon_username = options[:marathon_username]
+  MarathonDeploy::MarathonDefaults::marathon_password = options[:marathon_password]
 end
 
 $LOG = options[:logfile] ? Logger.new(options[:logfile]) : Logger.new(STDOUT)

--- a/lib/marathon_deploy/http_util.rb
+++ b/lib/marathon_deploy/http_util.rb
@@ -18,6 +18,9 @@ module MarathonDeploy
       http.open_timeout = @@o_timeout
       http.read_timeout = @@r_timeout
       req = Net::HTTP.const_get(method).new(uri.request_uri)
+      if MarathonDeploy::MarathonDefaults::marathon_username and MarathonDeploy::MarathonDefaults::marathon_password
+        req.basic_auth(MarathonDeploy::MarathonDefaults::marathon_username, MarathonDeploy::MarathonDefaults::marathon_password)
+      end
       if payload
         req.body = payload.to_json
       end

--- a/lib/marathon_deploy/http_util.rb
+++ b/lib/marathon_deploy/http_util.rb
@@ -14,6 +14,7 @@ module MarathonDeploy
     uri = construct_uri url 
     begin
       http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == 'https'
       http.open_timeout = @@o_timeout
       http.read_timeout = @@r_timeout
       req = Net::HTTP.const_get(method).new(uri.request_uri)

--- a/lib/marathon_deploy/http_util.rb
+++ b/lib/marathon_deploy/http_util.rb
@@ -10,39 +10,37 @@ module MarathonDeploy
 @@og_timeout = 60.0
 @@rg_timeout = 60.0
 
-  def self.put(url,payload)
+  def self.req(method, url, payload=nil, errors_are_fatal=false)
     uri = construct_uri url 
     begin
       http = Net::HTTP.new(uri.host, uri.port)
       http.open_timeout = @@o_timeout
       http.read_timeout = @@r_timeout
-      req = Net::HTTP::Put.new(uri.request_uri)
-      req.body = payload.to_json
+      req = Net::HTTP.const_get(method).new(uri.request_uri)
+      if payload
+        req.body = payload.to_json
+      end
       req["Content-Type"] = "application/json"
       response = http.request(req)
     rescue Exception => e
-      $LOG.error("Error calling marathon api: #{e.message}")
-      exit!
+      if errors_are_fatal
+        $LOG.error("Error calling marathon api: #{e.message}")
+        exit!
+      else
+        message = "Error calling marathon api: #{e.message}"
+        $LOG.error(message)
+        raise Error::MarathonError, message, caller
+      end
     end
     return response
   end
+
+  def self.put(url,payload)
+    return self.req('Put', url, payload, true)
+  end
   
   def self.post(url, payload)
-    uri = construct_uri url 
-    begin
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.open_timeout = @@o_timeout
-      http.read_timeout = @@r_timeout
-      req = Net::HTTP::Post.new(uri.request_uri)
-      req.body = payload.to_json
-      req["Content-Type"] = "application/json"
-      response = http.request(req)
-    rescue Exception => e
-      message = "Error calling marathon api: #{e.message}"
-      $LOG.error(message)
-      raise Error::MarathonError, message, caller
-    end
-    return response
+    return self.req('Post', url, payload, false)
   end
   
   def self.construct_uri(url)
@@ -51,19 +49,7 @@ module MarathonDeploy
   end
   
   def self.delete(url)
-    uri = construct_uri url 
-       begin
-         http = Net::HTTP.new(uri.host, uri.port)
-         http.open_timeout = @@o_timeout
-         http.read_timeout = @@r_timeout
-         req = Net::HTTP::Delete.new(uri.request_uri)         
-         response = http.request(req)
-       rescue Exception => e
-         message = "Error calling marathon api: #{e.message}"
-         $LOG.error(message)
-         raise Error::MarathonError, message, caller
-       end
-       return response    
+    return self.req('Delete', url, nil, false)
   end
   
   def self.clean_url(url)
@@ -71,21 +57,7 @@ module MarathonDeploy
   end
   
   def self.get(url)
-    uri = construct_uri url
-    begin
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.open_timeout = @@og_timeout
-      http.read_timeout = @@rg_timeout
-#      http.set_debug_output($stdout)
-      req = Net::HTTP::Get.new(uri.request_uri)
-      req["Content-Type"] = "application/json"
-      response = http.request(req)
-    rescue Exception => e
-      message = "Error calling marathon api: #{e.message}"
-      $LOG.error(message)
-      raise Error::MarathonError, message, caller
-    end
-    return  response
+    return self.req('Get', url, nil, false)
   end
   
   def self.valid_url(url)

--- a/lib/marathon_deploy/marathon_defaults.rb
+++ b/lib/marathon_deploy/marathon_defaults.rb
@@ -5,6 +5,10 @@ require 'logger'
 module MarathonDeploy
   module MarathonDefaults
  
+  class << self
+    attr_accessor :marathon_username, :marathon_password
+  end
+
   DEPLOYMENT_RECHECK_INTERVAL = 3
   DEPLOYMENT_TIMEOUT = 300
   HEALTHY_WAIT_TIMEOUT = 300
@@ -23,6 +27,8 @@ module MarathonDeploy
   DEFAULT_REMOVE_ELEMENTS = []
   DEFAULT_KEEP_ELEMENTS = [':id']
   ENVIRONMENT_VARIABLE_PREFIX = 'MARATHON_DEPLOY_'
+  marathon_username = nil
+  marathon_password = nil
 
   @@preproduction_override = {
     :instances => 5,


### PR DESCRIPTION
This series of patches adds support for basic authentication and SSL terminated marathon endpoints. Along the way, I DRY'ed up http_util a bit so it was easier to make changes to all methods.
