### PR TITLE
Added option to ignore the preproduction defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ Executables from this gem:
 ```
 >marathon_deploy -h
 Usage: bin/marathon_deploy [options]
-    -u, --url MARATHON_URL(S)        Default: ["http://localhost:8080"]
-    -l, --logfile LOGFILE            Default: STDOUT
-    -d, --debug                      Run in debug mode
-    -v, --version                    Version info
-    -f, --force                      Force deployment when sending same deploy JSON to Marathon
-    -n, --noop                       No action. Just display what would be performed.
-    -e, --environment ENVIRONMENT    Default: PREPRODUC
+    -u, --url MARATHON_URL(S)             Default: ["http://localhost:8080"]
+    -l, --logfile LOGFILE                 Default: STDOUT
+    -d, --debug                           Run in debug mode
+    -v, --version                         Version info
+    -f, --force                           Force deployment when sending same deploy JSON to Marathon
+    -n, --noop                            No action. Just display what would be performed.
+    -i, --ignore-preproduction-defaults   Ignores the preproduction defaults for cpu, memory, and instance limits
+    -e, --environment ENVIRONMENT         Default: PREPRODUC
 ```
 
 ### Overriding configuration based on environment

--- a/bin/marathon_deploy
+++ b/bin/marathon_deploy
@@ -21,16 +21,17 @@ options[:logfile] = MarathonDeploy::MarathonDefaults::DEFAULT_LOGFILE
 options[:force] = MarathonDeploy::MarathonDefaults::DEFAULT_FORCE_DEPLOY
 options[:noop] = MarathonDeploy::MarathonDefaults::DEFAULT_NOOP
 options[:remove_elements] = MarathonDeploy::MarathonDefaults::DEFAULT_REMOVE_ELEMENTS
+options[:ignore_preproduction_defaults] = MarathonDeploy::MarathonDefaults::DEFAULT_IGNORE_PREPRODUCTION_DEFAULTS
 options[:marathon_username] = nil
 options[:marathon_password] = nil
-  
-  
+
+
 OptionParser.new do |opts|
   opts.banner = "Usage: #{$0} [options]"
   opts.release =  MarathonDeploy::VERSION
-  
-  opts.on("-u","--url MARATHON_URL(S)", Array, "Default: #{options[:marathon_endpoints]}") do |u|    
-    options[:marathon_endpoints] = u  
+
+  opts.on("-u","--url MARATHON_URL(S)", Array, "Default: #{options[:marathon_endpoints]}") do |u|
+    options[:marathon_endpoints] = u
   end
 
   opts.on("-U","--username USERNAME", "Marathon authentication username") do |u|
@@ -40,15 +41,15 @@ OptionParser.new do |opts|
   opts.on("-p","--password PASSWORD", "Marathon authentication password") do |p|
     options[:marathon_password] = p
   end
-    
+
   opts.on("-l", "--logfile LOGFILE", "Default: STDOUT") do |l|
-    options[:logfile] = l  
+    options[:logfile] = l
   end
-  
+
   opts.on("-d", "--debug", "Run in debug mode") do |d|
     options[:debug] = Logger::DEBUG
   end
-  
+
   opts.on("-v", "--version", "Version info") do |v|
     puts "#{$0} version #{opts.release}"
     exit
@@ -70,11 +71,15 @@ OptionParser.new do |opts|
     options[:environment] = e
   end
 
+  opts.on("-i", "--ignore-preproduction-defaults", "Default: #{options[:ignore_preproduction_defaults]}" ) do |i|
+    options[:ignore_preproduction_defaults] = true
+  end
+
   opts.on_tail("-h", "--help", "Show this message") do
     puts opts
     puts "   ----------------- Additional Info -----------------", <<-DESCRIPTION
     * Marathon Env  variables:
-      - Env variables with the prefix "#{MarathonDeploy::MarathonDefaults::ENVIRONMENT_VARIABLE_PREFIX}" will be injected into the deployment plan.  
+      - Env variables with the prefix "#{MarathonDeploy::MarathonDefaults::ENVIRONMENT_VARIABLE_PREFIX}" will be injected into the deployment plan.
       - The prefix "#{MarathonDeploy::MarathonDefaults::ENVIRONMENT_VARIABLE_PREFIX}" will be removed before being added to the marathon json payload.
       - Example:  Env variable #{MarathonDeploy::MarathonDefaults::ENVIRONMENT_VARIABLE_PREFIX}DEBUG=True with be passed as DEBUG=True to the marathon-api.
     * Macros:
@@ -83,8 +88,8 @@ OptionParser.new do |opts|
       - If any marcos are not defined by Env variables, deployment will fail.
     DESCRIPTION
     exit
-  end 
-  
+  end
+
 end.parse!
 
 abort("Ambiguous arguments: #{ARGV.join(',')}. Only one deploy file argument may be passed.") if (ARGV.length > 1)
@@ -97,7 +102,7 @@ if (!argfile.nil?)
 elsif (File.file?(DEFAULT_DEPLOYFILE))
   deployfile = DEFAULT_DEPLOYFILE
 else
-  abort("No deploy file argument provided and default \'#{DEFAULT_DEPLOYFILE}\' does not exist in current directory \'#{Dir.pwd}\'")  
+  abort("No deploy file argument provided and default \'#{DEFAULT_DEPLOYFILE}\' does not exist in current directory \'#{Dir.pwd}\'")
 end
 
 if options[:marathon_username] and options[:marathon_password]
@@ -108,9 +113,9 @@ end
 $LOG = options[:logfile] ? Logger.new(options[:logfile]) : Logger.new(STDOUT)
 $LOG.level = options[:debug]
 
-noop = options[:noop]  
+noop = options[:noop]
 environment = MarathonDeploy::Environment.new(options[:environment])
-    
+
 marathon_endpoints = Array.new
   if (options[:marathon_endpoints].nil?)
     if (environment.is_production?)
@@ -131,7 +136,7 @@ remove_elements = Array.new
       eval n if not MarathonDeploy::MarathonDefaults::DEFAULT_KEEP_ELEMENTS.include? n
     end
   end
- 
+
 begin
   application = MarathonDeploy::Application.new(
       :deployfile => deployfile,
@@ -155,8 +160,10 @@ rescue MarathonDeploy::Error::BadFormatError => e
   exit!
 end
 
-if (!environment.is_production?)
-  application.overlay_preproduction_settings
+unless options[:ignore_preproduction_defaults]
+  if (!environment.is_production?)
+    application.overlay_preproduction_settings
+  end
 end
 
 display_msg = " MARATHON JSON DEPLOYMENT INSTRUCTIONS "
@@ -171,7 +178,7 @@ marathon_endpoints.each do |marathon_url|
     next if (noop)
     client = MarathonDeploy::MarathonClient.new(marathon_url)
     client.application = application
-    client.deploy  
+    client.deploy
   rescue MarathonDeploy::Error::MissingMarathonAttributesError,MarathonDeploy::Error::BadURLError, Timeout::Error => e
     $LOG.error(e.message)
     exit!

--- a/lib/marathon_deploy/marathon_defaults.rb
+++ b/lib/marathon_deploy/marathon_defaults.rb
@@ -4,7 +4,7 @@ require 'logger'
 
 module MarathonDeploy
   module MarathonDefaults
- 
+
   class << self
     attr_accessor :marathon_username, :marathon_password
   end
@@ -25,6 +25,7 @@ module MarathonDeploy
   MARATHON_DEPLOYMENT_REST_PATH = '/v2/deployments/'
   DEFAULT_FORCE_DEPLOY = false
   DEFAULT_NOOP = false
+  DEFAULT_IGNORE_PREPRODUCTION_DEFAULTS = false
   DEFAULT_REMOVE_ELEMENTS = []
   DEFAULT_KEEP_ELEMENTS = [':id']
   ENVIRONMENT_VARIABLE_PREFIX = 'MARATHON_DEPLOY_'
@@ -44,37 +45,37 @@ module MarathonDeploy
   }
 
   @@required_marathon_env_variables = %w[]
-  
+
   #@@required_marathon_attributes = %w[id env container healthChecks args storeUrls].map(&:to_sym)
   @@required_marathon_attributes = %w[id].map(&:to_sym)
-   
+
   def self.missing_attributes(json)
     json = Utils.symbolize(json)
     missing = []
     @@required_marathon_attributes.each do |att|
       if (!json[att])
-        missing << att 
+        missing << att
       end
     end
     return missing
   end
-  
+
   def self.missing_envs(json)
     json = Utils.symbolize(json)
-    
+
     if (!json.key?(:env))
-      raise Error::MissingMarathonAttributesError, "no env attribute found in deployment file", caller 
+      raise Error::MissingMarathonAttributesError, "no env attribute found in deployment file", caller
     end
-    
+
     missing = []
     @@required_marathon_env_variables.each do |variable|
       if (!json[:env][variable])
-        missing << variable 
+        missing << variable
       end
     end
     return missing
-  end  
-  
+  end
+
   def self.overlay_preproduction_settings(json)
     json = Utils.deep_symbolize(json)
       @@preproduction_override.each do |property,value|
@@ -90,6 +91,6 @@ module MarathonDeploy
       end
       return json
   end
-  
+
   end
 end


### PR DESCRIPTION
We have multiple environments with a variety of names and require the ability to override the preproduction limits without needing to specify PRODUCTION with -e. 